### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/julienbardi/homelab/security/code-scanning/1](https://github.com/julienbardi/homelab/security/code-scanning/1)

Add an explicit workflow-level `permissions` block in `.github/workflows/ci.yml` near the top-level keys (after `on:` is a clean location), setting the minimal required scope:

- `contents: read`

This preserves existing functionality (`actions/checkout` and linting) while enforcing least privilege for `GITHUB_TOKEN`. No imports, methods, or external definitions are needed because this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
